### PR TITLE
handshake fix for Chrome 20

### DIFF
--- a/server/lib/WebSocket/Connection.php
+++ b/server/lib/WebSocket/Connection.php
@@ -124,7 +124,11 @@ class Connection
 		$response.= "Upgrade: websocket\r\n";
 		$response.= "Connection: Upgrade\r\n";
 		$response.= "Sec-WebSocket-Accept: " . $secAccept . "\r\n";
-		$response.= "Sec-WebSocket-Protocol: " . substr($path, 1) . "\r\n\r\n";		
+		if (isset($headers['Sec-WebSocket-Protocol']))
+		{
+		    $response.= "Sec-WebSocket-Protocol: " . substr($path, 1) . "\r\n";
+		}
+		$response.= "\r\n";
 		if(false === ($this->server->writeBuffer($this->socket, $response)))
 		{
 			return false;


### PR DESCRIPTION
Server sending Sec-WebSocket-Protocol in the Response is only valid if the client sent Sec-WebSocket-Protocol in the Request.
http://tools.ietf.org/html/rfc6455#section-4.2.2
